### PR TITLE
labki-datetime: recover saved tz from full IANA list, preserve unknown offsets

### DIFF
--- a/resources/modules/ext.labki.datetime.js
+++ b/resources/modules/ext.labki.datetime.js
@@ -25,12 +25,27 @@
 
 		// Stored values carry a numeric offset but no IANA name; recover one
 		// so the dropdown reflects the saved zone instead of an unrelated
-		// fallback.
+		// fallback. Priority order:
+		//   1. user/default/wiki — disambiguates offsets shared by many zones
+		//      (e.g. +00:00 → UTC vs Europe/London in winter).
+		//   2. SHORTLIST — common picks round-trip even when they're outside
+		//      the user/default/wiki chain (Pacific/Mountain/Central/Eastern…).
+		//   3. All IANA zones — last-ditch coverage for non-shortlist picks
+		//      like Asia/Kolkata or Australia/Adelaide. May land on a sibling
+		//      with the same offset (Calcutta vs Kolkata); offset is preserved
+		//      and the user can adjust the dropdown if needed.
+		const shortlistIds = ( ( helpers.tz && helpers.tz.SHORTLIST ) || [] )
+			.map( ( z ) => z.id );
+		const allIanaIds = ( helpers.tz && typeof helpers.tz.getAllZones === 'function' ) ?
+			helpers.tz.getAllZones() :
+			[];
 		const recoveredTz = ( !state.tz && state.offset ) ?
 			helpers.resolveIanaFromOffset(
 				state.offset,
 				state.date,
 				[ cfg.userTz, cfg.defaultTz, cfg.wikiTz ]
+					.concat( shortlistIds )
+					.concat( allIanaIds )
 			) :
 			'';
 
@@ -39,11 +54,19 @@
 			state.tz || recoveredTz || helpers.tzFallback( cfg )
 		);
 
+		// True only while the dropdown still reflects the saved zone we
+		// inferred from `state.offset`. Lets sync() preserve a literal
+		// `state.offset` whose IANA we couldn't recover (rare: hand-edited
+		// values, future zones, etc.) instead of letting the dropdown's
+		// wiki-local fallback silently rewrite it on first sync.
+		let preserveSavedOffset = !!( state.offset && !state.tz && !recoveredTz );
+
 		function sync() {
 			const next = {
 				date: helpers.formatDate( dateEl ),
 				time: helpers.formatTime( timeEl ),
-				tz: tzSel ? tzSel.value : ''
+				tz: preserveSavedOffset ? '' : ( tzSel ? tzSel.value : '' ),
+				offset: preserveSavedOffset ? state.offset : ''
 			};
 			if ( hidden ) {
 				hidden.value = helpers.serializeValue( next );
@@ -83,7 +106,12 @@
 		}
 
 		if ( tzSel ) {
-			tzSel.addEventListener( 'change', sync );
+			tzSel.addEventListener( 'change', function () {
+				// User explicitly picked a zone — drop the saved-offset
+				// override so the dropdown becomes authoritative.
+				preserveSavedOffset = false;
+				sync();
+			} );
 		}
 
 		sync();

--- a/tests/scripts/check-shared-js.js
+++ b/tests/scripts/check-shared-js.js
@@ -201,6 +201,45 @@ check(
 	resolveIanaFromOffset( '', '2026-09-12', [ 'UTC' ] ),
 	''
 );
+// Regression: edit-page round-trip when the saved zone (Pacific) is *not*
+// in the user/default/wiki chain — the shortlist must be searched too,
+// otherwise the dropdown silently snaps back to "Wiki local".
+check(
+	'resolveIanaFromOffset finds shortlist zone outside user/default/wiki',
+	resolveIanaFromOffset(
+		'-07:00',
+		'2026-05-05',
+		[ '', '', 'UTC',
+			'UTC',
+			'America/Los_Angeles', 'America/Denver', 'America/Chicago', 'America/New_York' ]
+	),
+	'America/Los_Angeles'
+);
+// Regression: saved zone (Asia/Kolkata, +05:30) is outside both the
+// user/default/wiki chain *and* the SHORTLIST — must fall through to the
+// full IANA list so the offset isn't lost on edit. The match might be a
+// sibling alias (Calcutta vs Kolkata), so we just assert the recovered
+// zone produces the right offset on the anchor date rather than pinning
+// a specific name.
+( function () {
+	const recovered = resolveIanaFromOffset(
+		'+05:30',
+		'2026-05-05',
+		[ '', '', 'UTC' ].concat( [
+			'America/Los_Angeles', 'America/Denver', 'America/Chicago',
+			'America/New_York', 'UTC', 'Europe/London', 'Europe/Madrid',
+			'Europe/Berlin', 'Asia/Tokyo'
+		] ).concat( [
+			// stand-in for Intl.supportedValuesOf( 'timeZone' )
+			'Asia/Calcutta', 'Asia/Kolkata', 'Asia/Colombo'
+		] )
+	);
+	check(
+		'resolveIanaFromOffset falls through to all-IANA tier',
+		offsetFor( recovered, '2026-05-05' ),
+		'+05:30'
+	);
+}() );
 
 // getConfig — defaults applied when config keys absent
 ( function () {


### PR DESCRIPTION
## Problem

When re-editing a stored datetime like `2026-05-05T14:30:00-07:00`, the TZ dropdown silently snapped back to **Wiki local** instead of the originally-saved zone. Worse — `sync()` runs on init and rewrites the hidden field using the wiki-local fallback's offset, so the saved `±HH:MM` was clobbered the moment the edit form opened. Pure data loss on the first render.

Root cause: TZ recovery from the stored numeric offset only searched `[userTz, defaultTz, wikiTz]`. Any zone the user picked from the shortlist that wasn't already configured per-wiki (e.g. Pacific on a UTC-only wiki) couldn't round-trip.

## Fix

Three-tiered recovery in `ext.labki.datetime.js`:

| Tier | Source | Why |
|---|---|---|
| 1 | `[userTz, defaultTz, wikiTz]` | Disambiguates offsets shared by many zones (e.g. `+00:00` → UTC vs Europe/London in winter). |
| 2 | `helpers.tz.SHORTLIST` ids | Common picks (Pacific/Mountain/Central/Eastern, London/Madrid/Berlin/Tokyo) round-trip even when outside the user/default/wiki chain. |
| 3 | `helpers.tz.getAllZones()` (~600 IANA via `Intl.supportedValuesOf('timeZone')`) | Last-ditch coverage. May land on a sibling alias (`Asia/Calcutta` vs `Asia/Kolkata`); offset is preserved and `buildTzSelect` auto-expands to show it. |

### Belt-and-suspenders

For values that even tier 3 can't recover (hand-edited offsets, future zones the browser hasn't shipped, etc.), a `preserveSavedOffset` flag short-circuits `sync()` to write `state.offset` directly until the user picks a real zone from the dropdown. Prevents first-render rewrites for truly unrecoverable values.

### Honest caveat

Recovering an IANA name from a numeric offset is inherently lossy when multiple zones share an offset on the anchor date. E.g. on `2026-07-01`, both `Europe/Madrid` and `Europe/Berlin` are `+02:00` (CEST); the dropdown will show whichever appears first in the SHORTLIST (Madrid). Storage is bit-for-bit identical either way. Single-region wikis can pin their preferred name by setting `$wgLabkiPageFormsInputsWikiTz` so tier 1 matches first.

## Tests

- New regression: `resolveIanaFromOffset finds shortlist zone outside user/default/wiki` — tier-2 path.
- New regression: `resolveIanaFromOffset falls through to all-IANA tier` — tier-3 path; asserts the recovered zone produces the right offset on the anchor date rather than pinning a specific sibling name.
- Existing `serialize preserves offset when no tz` and `parse → serialize round-trip with offset` already cover the `preserveSavedOffset` short-circuit's storage path.
- 54/54 JS sanity tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)