### PR TITLE
Dark-mode overrides for flatpickr calendar/time popup and inputs

### DIFF
--- a/resources/modules/ext.labki.styles.less
+++ b/resources/modules/ext.labki.styles.less
@@ -19,3 +19,189 @@
 		max-width: 16em;
 	}
 }
+
+/* === Dark-mode overrides ===
+   The bundled `flatpickr.min.css` paints the calendar popup and the
+   visible date/time/tz input fields with hardcoded `#fff` / `#393939`
+   surfaces — readable in light mode, but bright pills on a dark page.
+   We paint dark variants when EITHER of the two standard color-mode
+   signals is set on <html>:
+     - `[data-bs-theme="dark"]` — Bootstrap 5.3's color-mode attribute,
+       used by any BS5.3-based skin (labki-platform's tweeki, others).
+     - `.skin-theme-clientpref-night` — MediaWiki's canonical class.
+   Either signal applies the override; labki-platform stamps both.
+   Tokens (`--labki-*`) are consulted with hex fallbacks so the rule
+   degrades gracefully when the extension is used outside Labki.
+   Selectors target the flatpickr-portaled `.flatpickr-calendar` (which
+   renders directly under <body>, so #content-scoped skin rules don't
+   reach it) and the in-form `.labki-pf-{date,time}` inputs themselves
+   (covering the case where a skin doesn't already paint
+   `input[type="text"]` for dark mode). */
+[data-bs-theme="dark"],
+.skin-theme-clientpref-night {
+	/* Visible input fields. */
+	.labki-pf-date,
+	.labki-pf-time,
+	.labki-pf-tz-select {
+		background-color: var(--labki-bg-subtle, #2c3033);
+		color: var(--labki-text, #e9ecef);
+		border-color: var(--labki-border, #495057);
+	}
+
+	/* Calendar popup body + arrow notch. The default uses #fff for
+	   the body and #e6e6e6 for the 1px outline-shadow; we re-tint
+	   both, matching the after/before arrow tip colors so the notch
+	   stays continuous with the body. */
+	.flatpickr-calendar {
+		background: var(--labki-bg-subtle, #2c3033);
+		color: var(--labki-text, #e9ecef);
+		box-shadow:
+			1px 0 0 var(--labki-border, #495057),
+			-1px 0 0 var(--labki-border, #495057),
+			0 1px 0 var(--labki-border, #495057),
+			0 -1px 0 var(--labki-border, #495057),
+			0 3px 13px rgba(0, 0, 0, 0.4);
+	}
+
+	.flatpickr-calendar.arrowTop:before { border-bottom-color: var(--labki-border, #495057); }
+	.flatpickr-calendar.arrowTop:after  { border-bottom-color: var(--labki-bg-subtle, #2c3033); }
+	.flatpickr-calendar.arrowBottom:before { border-top-color: var(--labki-border, #495057); }
+	.flatpickr-calendar.arrowBottom:after  { border-top-color: var(--labki-bg-subtle, #2c3033); }
+
+	/* Month nav row: text + chevron arrows. */
+	.flatpickr-months .flatpickr-month,
+	.flatpickr-current-month input.cur-year {
+		color: var(--labki-text, #e9ecef);
+		fill: var(--labki-text, #e9ecef);
+	}
+
+	.flatpickr-months .flatpickr-prev-month,
+	.flatpickr-months .flatpickr-next-month {
+		color: var(--labki-text, #e9ecef);
+		fill: var(--labki-text, #e9ecef);
+
+		&:hover svg { fill: var(--labki-accent, #6ea8fe); }
+	}
+
+	.flatpickr-current-month .flatpickr-monthDropdown-months {
+		background: var(--labki-bg-subtle, #2c3033);
+		color: var(--labki-text, #e9ecef);
+	}
+
+	.flatpickr-current-month .flatpickr-monthDropdown-months .flatpickr-monthDropdown-month {
+		background: var(--labki-bg-subtle, #2c3033);
+	}
+
+	/* Weekday header row + week-numbers column. */
+	.flatpickr-weekdays,
+	span.flatpickr-weekday {
+		background: var(--labki-bg-subtle, #2c3033);
+		color: var(--labki-text-muted, #adb5bd);
+	}
+
+	.flatpickr-weekwrapper .flatpickr-weeks { box-shadow: 1px 0 0 var(--labki-border, #495057); }
+	.flatpickr-weekwrapper span.flatpickr-day,
+	.flatpickr-weekwrapper span.flatpickr-day:hover {
+		color: var(--labki-text-muted, #adb5bd);
+		background: transparent;
+		border: none;
+	}
+
+	/* Day cells: default, hover, today, selected, in-range, disabled. */
+	.flatpickr-day {
+		color: var(--labki-text, #e9ecef);
+
+		&:hover,
+		&:focus,
+		&.prevMonthDay:hover,
+		&.nextMonthDay:hover {
+			background: var(--labki-border, #495057);
+			border-color: var(--labki-border, #495057);
+			color: var(--labki-text, #e9ecef);
+		}
+	}
+
+	.flatpickr-day.today {
+		border-color: var(--labki-accent, #6ea8fe);
+
+		&:hover,
+		&:focus {
+			background: var(--labki-accent, #6ea8fe);
+			border-color: var(--labki-accent, #6ea8fe);
+			color: #fff;
+		}
+	}
+
+	.flatpickr-day.selected,
+	.flatpickr-day.startRange,
+	.flatpickr-day.endRange,
+	.flatpickr-day.selected.inRange,
+	.flatpickr-day.startRange.inRange,
+	.flatpickr-day.endRange.inRange,
+	.flatpickr-day.selected:focus,
+	.flatpickr-day.startRange:focus,
+	.flatpickr-day.endRange:focus,
+	.flatpickr-day.selected:hover,
+	.flatpickr-day.startRange:hover,
+	.flatpickr-day.endRange:hover {
+		background: var(--labki-accent, #6ea8fe);
+		border-color: var(--labki-accent, #6ea8fe);
+		color: #fff;
+	}
+
+	.flatpickr-day.inRange {
+		background: var(--labki-border, #495057);
+		border-color: var(--labki-border, #495057);
+		box-shadow:
+			-5px 0 0 var(--labki-border, #495057),
+			5px 0 0 var(--labki-border, #495057);
+	}
+
+	.flatpickr-day.flatpickr-disabled,
+	.flatpickr-day.flatpickr-disabled:hover,
+	.flatpickr-day.prevMonthDay,
+	.flatpickr-day.nextMonthDay,
+	.flatpickr-day.notAllowed,
+	.flatpickr-day.notAllowed.prevMonthDay,
+	.flatpickr-day.notAllowed.nextMonthDay {
+		color: var(--labki-text-muted, #6c757d);
+		background: transparent;
+		border-color: transparent;
+	}
+
+	/* Time picker (bottom of calendar; also reused for time-only). */
+	.flatpickr-time {
+		border-top: 1px solid var(--labki-border, #495057);
+		background: var(--labki-bg-subtle, #2c3033);
+
+		input,
+		.flatpickr-time-separator,
+		.flatpickr-am-pm {
+			color: var(--labki-text, #e9ecef);
+			background: var(--labki-bg-subtle, #2c3033);
+		}
+
+		input:hover,
+		input:focus,
+		.flatpickr-am-pm:hover,
+		.flatpickr-am-pm:focus {
+			background: var(--labki-border, #495057);
+		}
+	}
+
+	/* Number-input arrow chevrons (year, hour, minute spinners). The
+	   default `border-{bottom,top}-color: rgba(0,0,0,0.9)` reads as
+	   black on dark; lift to text token. */
+	.flatpickr-current-month .numInputWrapper span.arrowUp:after,
+	.flatpickr-time .numInputWrapper span.arrowUp:after {
+		border-bottom-color: var(--labki-text, #e9ecef);
+	}
+	.flatpickr-current-month .numInputWrapper span.arrowDown:after,
+	.flatpickr-time .numInputWrapper span.arrowDown:after {
+		border-top-color: var(--labki-text, #e9ecef);
+	}
+
+	.numInputWrapper:hover { background: rgba(255, 255, 255, 0.05); }
+	.numInputWrapper span:hover  { background: rgba(255, 255, 255, 0.10); }
+	.numInputWrapper span:active { background: rgba(255, 255, 255, 0.15); }
+}


### PR DESCRIPTION
## Summary

Adds dark-mode re-paints for the bundled flatpickr calendar popup and the in-form date/time/tz input fields. The bundled `flatpickr.min.css` hardcodes `#fff` / `#393939` / `#e6e6e6` surfaces — readable in light mode, but renders as bright pills on a dark page when the host wiki is in dark mode.

## How it triggers

Gated by either of the two standard color-mode signals on `<html>`:

- `[data-bs-theme=\"dark\"]` — Bootstrap 5.3's color-mode attribute
- `.skin-theme-clientpref-night` — MediaWiki's canonical dark-mode class

`labki-platform` stamps both. Other dark-mode-aware BS5.3 skins that set at least one signal also activate the override. Skins without dark-mode awareness see no change.

## Token usage with hex fallback

All re-paints consult `--labki-*` tokens (defined by `labki-platform`) with hex fallbacks chosen from the Bootstrap-dark palette. So:

- **Under Labki** → tokens flip with theme automatically.
- **Standalone** (no Labki tokens) → fallback hex values render a coherent dark theme.
- **Light mode** → no override fires; original flatpickr appearance unchanged.

## Coverage

- `.labki-pf-{date,time,tz-select}` visible input fields
- `.flatpickr-calendar` body, arrow notch, box-shadow
- Month nav, month dropdown, weekday header, week-numbers column
- Day cells: default, hover, today, selected, in-range, disabled, prev/next-month
- Time picker: bg, separator, am/pm, input hover
- Numeric spinner up/down chevrons (year, hour, minute)

## Test plan

- [ ] Open a form with date / datetime / time fields in **light** mode → calendar popup and inputs unchanged from before.
- [ ] Toggle host wiki to **dark** mode → input field bgs flip to dark; opening the calendar shows a dark popup with all surfaces (header, day grid, time picker) styled coherently.
- [ ] Hover and click days → hover state, today indicator, selected state all readable on dark.
- [ ] Time picker spinner arrows visible against the dark bg.
- [ ] On a non-Labki host using BS5.3 \`[data-bs-theme=\"dark\"]\` (or a manually-set \`.skin-theme-clientpref-night\` for testing), confirm the fallback hex palette renders coherently without Labki tokens.

## Note

Does **not** modify the vendored `lib/flatpickr/flatpickr.min.css` — overrides live in our own `ext.labki.styles.less`, so the vendored file stays pristine for future flatpickr upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)